### PR TITLE
Enable linux-aarch64 builds

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -40,6 +40,38 @@ jobs:
         CONFIG: linux_64_cuda_compiler_version12.9cxx_compiler_version14python3.13.____cp313
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_aarch64_cuda_compiler_version12.6cxx_compiler_version13python3.10.____cpython:
+        CONFIG: linux_aarch64_cuda_compiler_version12.6cxx_compiler_version13python3.10.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_aarch64_cuda_compiler_version12.6cxx_compiler_version13python3.11.____cpython:
+        CONFIG: linux_aarch64_cuda_compiler_version12.6cxx_compiler_version13python3.11.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_aarch64_cuda_compiler_version12.6cxx_compiler_version13python3.12.____cpython:
+        CONFIG: linux_aarch64_cuda_compiler_version12.6cxx_compiler_version13python3.12.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_aarch64_cuda_compiler_version12.6cxx_compiler_version13python3.13.____cp313:
+        CONFIG: linux_aarch64_cuda_compiler_version12.6cxx_compiler_version13python3.13.____cp313
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_aarch64_cuda_compiler_version12.9cxx_compiler_version14python3.10.____cpython:
+        CONFIG: linux_aarch64_cuda_compiler_version12.9cxx_compiler_version14python3.10.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_aarch64_cuda_compiler_version12.9cxx_compiler_version14python3.11.____cpython:
+        CONFIG: linux_aarch64_cuda_compiler_version12.9cxx_compiler_version14python3.11.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_aarch64_cuda_compiler_version12.9cxx_compiler_version14python3.12.____cpython:
+        CONFIG: linux_aarch64_cuda_compiler_version12.9cxx_compiler_version14python3.12.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_aarch64_cuda_compiler_version12.9cxx_compiler_version14python3.13.____cp313:
+        CONFIG: linux_aarch64_cuda_compiler_version12.9cxx_compiler_version14python3.13.____cp313
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
   timeoutInMinutes: 360
   variables: {}
 

--- a/.ci_support/linux_aarch64_cuda_compiler_version12.6cxx_compiler_version13python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_cuda_compiler_version12.6cxx_compiler_version13python3.10.____cpython.yaml
@@ -1,0 +1,34 @@
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- '12.6'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '13'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+pytorch:
+- '2.7'
+target_platform:
+- linux-aarch64
+zip_keys:
+- - cxx_compiler_version
+  - c_stdlib_version
+  - cuda_compiler_version

--- a/.ci_support/linux_aarch64_cuda_compiler_version12.6cxx_compiler_version13python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_cuda_compiler_version12.6cxx_compiler_version13python3.11.____cpython.yaml
@@ -1,0 +1,34 @@
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- '12.6'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '13'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.11.* *_cpython
+pytorch:
+- '2.7'
+target_platform:
+- linux-aarch64
+zip_keys:
+- - cxx_compiler_version
+  - c_stdlib_version
+  - cuda_compiler_version

--- a/.ci_support/linux_aarch64_cuda_compiler_version12.6cxx_compiler_version13python3.12.____cpython.yaml
+++ b/.ci_support/linux_aarch64_cuda_compiler_version12.6cxx_compiler_version13python3.12.____cpython.yaml
@@ -1,0 +1,34 @@
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- '12.6'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '13'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
+pytorch:
+- '2.7'
+target_platform:
+- linux-aarch64
+zip_keys:
+- - cxx_compiler_version
+  - c_stdlib_version
+  - cuda_compiler_version

--- a/.ci_support/linux_aarch64_cuda_compiler_version12.6cxx_compiler_version13python3.13.____cp313.yaml
+++ b/.ci_support/linux_aarch64_cuda_compiler_version12.6cxx_compiler_version13python3.13.____cp313.yaml
@@ -1,0 +1,34 @@
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- '12.6'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '13'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.13.* *_cp313
+pytorch:
+- '2.7'
+target_platform:
+- linux-aarch64
+zip_keys:
+- - cxx_compiler_version
+  - c_stdlib_version
+  - cuda_compiler_version

--- a/.ci_support/linux_aarch64_cuda_compiler_version12.9cxx_compiler_version14python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_cuda_compiler_version12.9cxx_compiler_version14python3.10.____cpython.yaml
@@ -1,0 +1,34 @@
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- '12.9'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+pytorch:
+- '2.7'
+target_platform:
+- linux-aarch64
+zip_keys:
+- - cxx_compiler_version
+  - c_stdlib_version
+  - cuda_compiler_version

--- a/.ci_support/linux_aarch64_cuda_compiler_version12.9cxx_compiler_version14python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_cuda_compiler_version12.9cxx_compiler_version14python3.11.____cpython.yaml
@@ -1,0 +1,34 @@
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- '12.9'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.11.* *_cpython
+pytorch:
+- '2.7'
+target_platform:
+- linux-aarch64
+zip_keys:
+- - cxx_compiler_version
+  - c_stdlib_version
+  - cuda_compiler_version

--- a/.ci_support/linux_aarch64_cuda_compiler_version12.9cxx_compiler_version14python3.12.____cpython.yaml
+++ b/.ci_support/linux_aarch64_cuda_compiler_version12.9cxx_compiler_version14python3.12.____cpython.yaml
@@ -1,0 +1,34 @@
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- '12.9'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
+pytorch:
+- '2.7'
+target_platform:
+- linux-aarch64
+zip_keys:
+- - cxx_compiler_version
+  - c_stdlib_version
+  - cuda_compiler_version

--- a/.ci_support/linux_aarch64_cuda_compiler_version12.9cxx_compiler_version14python3.13.____cp313.yaml
+++ b/.ci_support/linux_aarch64_cuda_compiler_version12.9cxx_compiler_version14python3.13.____cp313.yaml
@@ -1,0 +1,34 @@
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- '12.9'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.13.* *_cp313
+pytorch:
+- '2.7'
+target_platform:
+- linux-aarch64
+zip_keys:
+- - cxx_compiler_version
+  - c_stdlib_version
+  - cuda_compiler_version

--- a/README.md
+++ b/README.md
@@ -82,6 +82,62 @@ Current build status
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/causal-conv1d-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cuda_compiler_version12.9cxx_compiler_version14python3.13.____cp313" alt="variant">
                 </a>
               </td>
+            </tr><tr>
+              <td>linux_aarch64_cuda_compiler_version12.6cxx_compiler_version13python3.10.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=25681&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/causal-conv1d-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_cuda_compiler_version12.6cxx_compiler_version13python3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_cuda_compiler_version12.6cxx_compiler_version13python3.11.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=25681&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/causal-conv1d-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_cuda_compiler_version12.6cxx_compiler_version13python3.11.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_cuda_compiler_version12.6cxx_compiler_version13python3.12.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=25681&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/causal-conv1d-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_cuda_compiler_version12.6cxx_compiler_version13python3.12.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_cuda_compiler_version12.6cxx_compiler_version13python3.13.____cp313</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=25681&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/causal-conv1d-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_cuda_compiler_version12.6cxx_compiler_version13python3.13.____cp313" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_cuda_compiler_version12.9cxx_compiler_version14python3.10.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=25681&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/causal-conv1d-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_cuda_compiler_version12.9cxx_compiler_version14python3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_cuda_compiler_version12.9cxx_compiler_version14python3.11.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=25681&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/causal-conv1d-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_cuda_compiler_version12.9cxx_compiler_version14python3.11.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_cuda_compiler_version12.9cxx_compiler_version14python3.12.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=25681&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/causal-conv1d-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_cuda_compiler_version12.9cxx_compiler_version14python3.12.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_cuda_compiler_version12.9cxx_compiler_version14python3.13.____cp313</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=25681&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/causal-conv1d-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_cuda_compiler_version12.9cxx_compiler_version14python3.13.____cp313" alt="variant">
+                </a>
+              </td>
             </tr>
           </tbody>
         </table>

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -4,6 +4,8 @@ azure:
     variables:
       CONDA_BLD_PATH: C:\\bld\\
       MINIFORGE_HOME: C:\Miniforge
+build_platform:
+  linux_aarch64: linux_64
 github:
   branch_name: main
   tooling_branch_name: main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,12 +33,13 @@ requirements:
     - {{ compiler('cuda') }}
     - {{ stdlib('c') }}
     - cross-python_{{ target_platform }}    # [build_platform != target_platform]
+    - cython                                # [build_platform != target_platform]
     - sed     # [unix]
     - m2-sed  # [win]
+    - python                                # [build_platform != target_platform]
     - pytorch                               # [build_platform != target_platform]
   host:
     - cuda-toolkit
-    - cython
     - ninja
     - packaging
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,7 @@ source:
 
 build:
   number: 3
+  string: cuda{{ cuda_compiler_version | replace('.', '') }}py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
   script:
     - export CAUSAL_CONV1D_FORCE_BUILD=TRUE      # [unix]
     - export CAUSAL_CONV1D_FORCE_CXX11_ABI=TRUE  # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
     sha256: 53fabaf24436d5bb4e1af261961cc22cc8203ca10cc3b618e5c8462c3a4be3de
 
 build:
-  number: 2
+  number: 3
   script:
     - export CAUSAL_CONV1D_FORCE_BUILD=TRUE      # [unix]
     - export CAUSAL_CONV1D_FORCE_CXX11_ABI=TRUE  # [unix]
@@ -32,8 +32,10 @@ requirements:
     - {{ compiler('cxx') }}
     - {{ compiler('cuda') }}
     - {{ stdlib('c') }}
+    - cross-python_{{ target_platform }}    # [build_platform != target_platform]
     - sed     # [unix]
     - m2-sed  # [win]
+    - pytorch                               # [build_platform != target_platform]
   host:
     - cuda-toolkit
     - cython


### PR DESCRIPTION
Arch migration was triggered at https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/7764 for `mamba-ssm` that depends on `causal-conv1d`, but stuck at https://conda-forge.org/status/migration/?name=aarch64andppc64leaddition due to https://github.com/conda-forge/pytorch-cpu-feedstock/pull/226 (technically pytorch has linux-aarch64 already though), hence this manual migration PR.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
