### PR TITLE
Document CUDA platform skips

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -16,6 +16,9 @@ source:
 build:
   number: ${{ build_number }}
   string: ${{ "cuda" ~ (cuda_compiler_version | replace(".", "")) ~ "py" ~ (python | version_to_buildstring) ~ "h" ~ hash ~ "_" ~ build_number }}
+  # Upstream only provides a CUDA extension. Keep no-CUDA and Windows variants
+  # disabled until the PyTorch/CUDA compiler stack can build and test them here;
+  # CUDA 11.8 is outside this feedstock's current PyTorch 2.10 CUDA matrix.
   skip:
     - cuda_compiler_version == "None" or cuda_compiler_version == "11.8" or win
   script:


### PR DESCRIPTION
## Summary
- document why the recipe intentionally skips no-CUDA, CUDA 11.8, and Windows variants
- no package metadata or build number changes

## Test plan
- `git diff --check`
- `git diff --cached --check`
- `conda-smithy lint --conda-forge recipe`